### PR TITLE
모바일 앱 환경 로그인 API 추가

### DIFF
--- a/src/main/java/hexfive/ismedi/global/swagger/AuthControllerDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/AuthControllerDocs.java
@@ -14,9 +14,22 @@ import org.springframework.web.servlet.view.RedirectView;
 
 public interface AuthControllerDocs {
 
-    @Operation(summary = "카카오 로그인 요청", description = "카카오 인증 서버로 리다이렉트합니다.")
+    @Operation(summary = "웹 카카오 로그인 요청", description = "카카오 인증 서버로 리다이렉트합니다.")
     @GetMapping("/login")
     RedirectView kakaoLogin();
+
+    @Operation(
+            summary = "앱 카카오 로그인 요청",
+            description = "앱에서 발급받은 카카오 access_token을 이용해 로그인합니다. 신규 유저일 경우 isNew=true로 응답됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "기존 유저 or 신규 유저 구분 응답"),
+            @ApiResponse(responseCode = "400", description = "[INVALID_TOKEN] 유효하지 않은 카카오 토큰"),
+            @ApiResponse(responseCode = "403", description = "토큰 인증 실패")
+    })
+    @Parameter(hidden = true)
+    @PostMapping("/login/app")
+    APIResponse<KaKaoLoginResultDto> kakaoAppLogin(@RequestHeader("Authorization") String header);
 
     @Operation(summary = "카카오 로그인 콜백", description = "인가 코드를 처리하여 사용자 정보를 조회합니다.")
     @ApiResponses({

--- a/src/main/java/hexfive/ismedi/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hexfive/ismedi/jwt/JwtAuthenticationFilter.java
@@ -33,7 +33,10 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        if (httpRequest.getRequestURI().equals("/api/auth/reissue") || httpRequest.getRequestURI().equals("/api/auth/logout")) {
+        if (
+                httpRequest.getRequestURI().equals("/api/auth/reissue")
+                        || httpRequest.getRequestURI().equals("/api/auth/logout")
+                        || httpRequest.getRequestURI().equals("/api/auth/login/app")) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/hexfive/ismedi/oauth/AuthController.java
+++ b/src/main/java/hexfive/ismedi/oauth/AuthController.java
@@ -4,6 +4,7 @@ import hexfive.ismedi.global.response.APIResponse;
 import hexfive.ismedi.global.exception.CustomException;
 import hexfive.ismedi.global.swagger.AuthControllerDocs;
 import hexfive.ismedi.jwt.TokenDto;
+import hexfive.ismedi.oauth.dto.KakaoUserInfoDto;
 import hexfive.ismedi.oauth.dto.SignupRequestDto;
 import hexfive.ismedi.users.dto.KaKaoLoginResultDto;
 import io.jsonwebtoken.JwtException;
@@ -41,10 +42,15 @@ public class AuthController implements AuthControllerDocs {
         return new RedirectView(kakaoAuthUrl);
     }
 
+    @PostMapping("/login/app")
+    public APIResponse<KaKaoLoginResultDto> kakaoAppLogin(@RequestHeader("Authorization") String header){
+        String AuthorizationCode = header.substring(7);
+        return APIResponse.success(authService.kakaoLoginByAccessToken(AuthorizationCode));
+    }
+
     @GetMapping("/login/kakao/callback")
     public APIResponse<KaKaoLoginResultDto> kakaoCallback(@RequestParam String code){
-        KaKaoLoginResultDto result = authService.kakaoLogin(code);
-        return APIResponse.success(result);
+        return APIResponse.success(authService.kakaoLoginByAuthorizationCode(code));
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/hexfive/ismedi/oauth/AuthController.java
+++ b/src/main/java/hexfive/ismedi/oauth/AuthController.java
@@ -44,8 +44,8 @@ public class AuthController implements AuthControllerDocs {
 
     @PostMapping("/login/app")
     public APIResponse<KaKaoLoginResultDto> kakaoAppLogin(@RequestHeader("Authorization") String header){
-        String AuthorizationCode = header.substring(7);
-        return APIResponse.success(authService.kakaoLoginByAccessToken(AuthorizationCode));
+        String accessToken = header.substring(7);
+        return APIResponse.success(authService.kakaoLoginByAccessToken(accessToken));
     }
 
     @GetMapping("/login/kakao/callback")

--- a/src/main/java/hexfive/ismedi/oauth/AuthService.java
+++ b/src/main/java/hexfive/ismedi/oauth/AuthService.java
@@ -51,11 +51,16 @@ public class AuthService {
     @Value("${kakao.client-secret}")
     private String clientSecret;
 
-    public KaKaoLoginResultDto kakaoLogin(String code) {
-        String kakaoAccessToken = getAccessToken(code);
+    public KaKaoLoginResultDto kakaoLoginByAuthorizationCode(String AuthorizationCode){
+        return handleKakaoLogin(getAccessToken(AuthorizationCode));
+    }
 
+    public KaKaoLoginResultDto kakaoLoginByAccessToken(String kakaoAccessToken){
+        return handleKakaoLogin(kakaoAccessToken);
+    }
+
+    private KaKaoLoginResultDto handleKakaoLogin(String kakaoAccessToken){
         KakaoUserInfoDto userInfo = getUserInfoByAccessToken(kakaoAccessToken);
-
         KaKaoLoginResultDto result = loginOrJoin(userInfo);
 
         // 신규 회원


### PR DESCRIPTION
close #21 

## 📝 기능 설명
앱/웹 카카오 로그인 로직이 달라 앱에서 사용할 로그인 api 추가하였습니다.

## 🛠 작업 사항
클라이언트에서 JavaScript SDK를 통해 사용자 정보 AccessToken 받아서 서버로 전달,
서버에서는 해당 토큰으로 사용자 정보 가져와서 로그인/회원가입 분기처리하도록 하였습니다.

![스크린샷 2025-04-24 230026](https://github.com/user-attachments/assets/5e81652d-19ae-44c6-af10-70ed29a7c214)
JavaScript SDK 대신 https://kauth.kakao.com/oauth/token로 직접 요청 보내고 토큰 받아서 테스트했습니다.

![스크린샷 2025-04-24 230009](https://github.com/user-attachments/assets/3ed3aa17-b63a-4cbd-ac0f-696e2051abae)
/api/auth/login/app 요청 후 응답 정상적으로 들어오는 것 확인했습니다.

## ✅ 작업 체크리스트
- [x] 앱 로그인 api 추가
- [x] SwaggerDocs 업데이트

## 📎 참고 자료

