### PR TITLE
#25 알림 CRUD 구현

### DIFF
--- a/src/main/java/hexfive/ismedi/domain/User.java
+++ b/src/main/java/hexfive/ismedi/domain/User.java
@@ -1,5 +1,6 @@
 package hexfive.ismedi.domain;
 
+import hexfive.ismedi.notification.Notification;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
+++ b/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     LOGOUT_TOKEN("LOGOUT_TOKEN", "로그아웃된 토큰입니다", HttpStatus.UNAUTHORIZED),
     MISSING_TOKEN("MISSING_TOKEN", "Access Token이 없습니다", HttpStatus.UNAUTHORIZED),
     LOGOUT_FAILED("LOGOUT_FAILED", "로그아웃 처리 중 문제가 발생했습니다. 토큰이 이미 만료되었거나 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED_ACCESS("UNAUTHORIZED_ACCESS", "해당 데이터에 대한 접근 권한이 없습니다", HttpStatus.FORBIDDEN),
 
     // Redis 관련
     REDIS_ERROR("REDIS_ERROR", "토큰 저장소(Redis) 처리 중 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
@@ -36,6 +37,12 @@ public enum ErrorCode {
 
     // Category
     CATEGORY_NOT_FOUND("CATEGORY_NOT_FOUND", "카테고리(id=%d)를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
+    // Notification
+    NOTIFICATION_NOT_FOUND("CATEGORY_NOT_FOUND", "알림(id=%d)를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
+    // User
+    USER_NOT_FOUND("CATEGORY_NOT_FOUND", "사용자(id=%d)를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
 
     // 기타
     INTERNAL_ERROR("INTERNAL_ERROR", "서버 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/hexfive/ismedi/global/swagger/AuthDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/AuthDocs.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
-public interface AuthControllerDocs {
+public interface AuthDocs {
 
     @Operation(summary = "웹 카카오 로그인 요청", description = "카카오 인증 서버로 리다이렉트합니다.")
     @GetMapping("/login")

--- a/src/main/java/hexfive/ismedi/global/swagger/MedicineDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/MedicineDocs.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-public interface MedicineControllerDocs {
+public interface MedicineDocs {
 
     @Operation(summary = "의약품 데이터 병합", description = "공공데이터 API에서 받아온 의약품 정보를 DB에 병합합니다.")
     @GetMapping("/init")

--- a/src/main/java/hexfive/ismedi/global/swagger/NotificationDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/NotificationDocs.java
@@ -1,0 +1,41 @@
+package hexfive.ismedi.global.swagger;
+
+import hexfive.ismedi.global.response.APIResponse;
+import hexfive.ismedi.notification.dto.NotificationDto;
+import hexfive.ismedi.notification.dto.ResNotificationDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Notification", description = "알림 관련 API - 로그인 후 사용 가능")
+public interface NotificationDocs {
+
+    @Operation(summary = "알림 생성", description = "알림을 생성합니다.")
+    APIResponse<ResNotificationDto> createNotification(
+            @Parameter(hidden = true) UserDetails userDetails,
+            @RequestBody NotificationDto createNotificationDto);
+
+    @Operation(summary = "단일 알림 조회", description = "알림 ID로 단일 알림을 조회합니다.")
+    APIResponse<ResNotificationDto> getNotification(
+            @Parameter(hidden = true) UserDetails userDetails,
+            @PathVariable Long id);
+
+    @Operation(summary = "모든 알림 조회", description = "해당 사용자의 모든 알림을 조회합니다.")
+    APIResponse<List<ResNotificationDto>> getAllNotifications(
+            @Parameter(hidden = true) UserDetails userDetails);
+
+    @Operation(summary = "알림 수정", description = "알림 ID로 알림을 수정합니다.")
+    APIResponse<ResNotificationDto> updateNotification(
+            @Parameter(hidden = true) UserDetails userDetails,
+            @PathVariable Long id,
+            @RequestBody NotificationDto updateNotificationDto);
+
+    @Operation(summary = "알림 삭제", description = "알림 ID로 알림을 삭제합니다.")
+    APIResponse<Void> deleteNotification(
+            @Parameter(hidden = true) UserDetails userDetails,
+            @PathVariable Long id);
+}

--- a/src/main/java/hexfive/ismedi/medicine/MedicineController.java
+++ b/src/main/java/hexfive/ismedi/medicine/MedicineController.java
@@ -1,7 +1,7 @@
 package hexfive.ismedi.medicine;
 
 import hexfive.ismedi.global.response.APIResponse;
-import hexfive.ismedi.global.swagger.MedicineControllerDocs;
+import hexfive.ismedi.global.swagger.MedicineDocs;
 import hexfive.ismedi.medicine.dto.ResMedicineDetailDto;
 import hexfive.ismedi.medicine.dto.ResMedicineDto;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +12,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/medicines")
-public class MedicineController implements MedicineControllerDocs {
+public class MedicineController implements MedicineDocs {
 
     private final MedicineService medicineService;
 

--- a/src/main/java/hexfive/ismedi/notification/Notification.java
+++ b/src/main/java/hexfive/ismedi/notification/Notification.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.*;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -27,5 +27,5 @@ public class Notification {
     private User user;
 
     @Column(nullable = false)
-    private Date time;
+    private LocalTime time;
 }

--- a/src/main/java/hexfive/ismedi/notification/Notification.java
+++ b/src/main/java/hexfive/ismedi/notification/Notification.java
@@ -1,8 +1,18 @@
-package hexfive.ismedi.domain;
+package hexfive.ismedi.notification;
+import hexfive.ismedi.domain.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.util.*;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "Notification")
 public class Notification {
     @Id

--- a/src/main/java/hexfive/ismedi/notification/Notification.java
+++ b/src/main/java/hexfive/ismedi/notification/Notification.java
@@ -1,5 +1,6 @@
 package hexfive.ismedi.notification;
 import hexfive.ismedi.domain.User;
+import hexfive.ismedi.notification.dto.NotificationDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,4 +29,9 @@ public class Notification {
 
     @Column(nullable = false)
     private LocalTime time;
+
+    public void update(NotificationDto notificationDto) {
+        this.name = notificationDto.getName();
+        this.time = notificationDto.getTime();
+    }
 }

--- a/src/main/java/hexfive/ismedi/notification/NotificationController.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationController.java
@@ -36,4 +36,12 @@ public class NotificationController {
         Long userId = Long.parseLong(userDetails.getUsername());
         return APIResponse.success(notificationService.getAllNotifications(userId));
     }
+
+    @PutMapping("/{id}")
+    public APIResponse<ResNotificationDto> updateNotification(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long id, @Valid @RequestBody NotificationDto updateNotificationDto) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return APIResponse.success(notificationService.updateNotification(userId, id, updateNotificationDto));
+    }
 }

--- a/src/main/java/hexfive/ismedi/notification/NotificationController.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationController.java
@@ -1,6 +1,7 @@
 package hexfive.ismedi.notification;
 
 import hexfive.ismedi.global.response.APIResponse;
+import hexfive.ismedi.global.swagger.NotificationDocs;
 import hexfive.ismedi.notification.dto.NotificationDto;
 import hexfive.ismedi.notification.dto.ResNotificationDto;
 import jakarta.validation.Valid;
@@ -14,7 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
-public class NotificationController {
+public class NotificationController implements NotificationDocs {
     private final NotificationService notificationService;
 
     @PostMapping

--- a/src/main/java/hexfive/ismedi/notification/NotificationController.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationController.java
@@ -1,0 +1,39 @@
+package hexfive.ismedi.notification;
+
+import hexfive.ismedi.global.response.APIResponse;
+import hexfive.ismedi.notification.dto.NotificationDto;
+import hexfive.ismedi.notification.dto.ResNotificationDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @PostMapping
+    public APIResponse<ResNotificationDto> createNotification(@AuthenticationPrincipal UserDetails userDetails,
+                                                              @Valid @RequestBody NotificationDto createNotificationDto) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return APIResponse.success(notificationService.createNotification(userId, createNotificationDto));
+    }
+
+    @GetMapping("/{id}")
+    public APIResponse<ResNotificationDto> getNotification(@AuthenticationPrincipal UserDetails userDetails,
+                                                           @PathVariable Long id) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return APIResponse.success(notificationService.getNotification(userId, id));
+    }
+
+    @GetMapping
+    public APIResponse<List<ResNotificationDto>> getAllNotifications(@AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return APIResponse.success(notificationService.getAllNotifications(userId));
+    }
+}

--- a/src/main/java/hexfive/ismedi/notification/NotificationController.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationController.java
@@ -44,4 +44,13 @@ public class NotificationController {
         Long userId = Long.parseLong(userDetails.getUsername());
         return APIResponse.success(notificationService.updateNotification(userId, id, updateNotificationDto));
     }
+
+    @DeleteMapping("/{id}")
+    public APIResponse<Void> deleteNotification(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long id) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        notificationService.deleteNotification(userId, id);
+        return APIResponse.success(null);
+    }
 }

--- a/src/main/java/hexfive/ismedi/notification/NotificationRepository.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationRepository.java
@@ -1,0 +1,11 @@
+package hexfive.ismedi.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserId(Long userId);
+}

--- a/src/main/java/hexfive/ismedi/notification/NotificationService.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationService.java
@@ -1,0 +1,53 @@
+package hexfive.ismedi.notification;
+
+import hexfive.ismedi.domain.User;
+import hexfive.ismedi.global.exception.CustomException;
+import hexfive.ismedi.notification.dto.NotificationDto;
+import hexfive.ismedi.notification.dto.ResNotificationDto;
+import hexfive.ismedi.users.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static hexfive.ismedi.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    public ResNotificationDto createNotification(Long userId, NotificationDto notificationDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND, userId));
+
+        Notification notification = Notification.builder()
+                .user(user)
+                .name(notificationDto.getName())
+                .time(notificationDto.getTime())
+                .build();
+        notificationRepository.save(notification);
+        return ResNotificationDto.fromEntity(notification);
+    }
+
+    public ResNotificationDto getNotification(Long userId, Long notificationId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND, userId));
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(NOTIFICATION_NOT_FOUND, notificationId));
+        if (!notification.getUser().equals(user))
+            throw new CustomException(UNAUTHORIZED_ACCESS);
+        return ResNotificationDto.fromEntity(notification);
+    }
+
+    public List<ResNotificationDto> getAllNotifications(Long userId) {
+        List<Notification> notifications = notificationRepository.findByUserId(userId);
+        return notifications.stream()
+                .map(ResNotificationDto::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/hexfive/ismedi/notification/NotificationService.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationService.java
@@ -50,4 +50,20 @@ public class NotificationService {
                 .map(ResNotificationDto::fromEntity)
                 .toList();
     }
+
+    public ResNotificationDto updateNotification(Long userId, Long notificationId, NotificationDto notificationDto) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(NOTIFICATION_NOT_FOUND, notificationId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND, userId));
+        if (!notification.getUser().equals(user))
+            throw new CustomException(UNAUTHORIZED_ACCESS);
+
+        notification.update(notificationDto);
+
+        notificationRepository.save(notification);
+
+        return ResNotificationDto.fromEntity(notification);
+    }
 }

--- a/src/main/java/hexfive/ismedi/notification/NotificationService.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationService.java
@@ -1,5 +1,6 @@
 package hexfive.ismedi.notification;
 
+import hexfive.ismedi.category.Category;
 import hexfive.ismedi.domain.User;
 import hexfive.ismedi.global.exception.CustomException;
 import hexfive.ismedi.notification.dto.NotificationDto;
@@ -65,5 +66,17 @@ public class NotificationService {
         notificationRepository.save(notification);
 
         return ResNotificationDto.fromEntity(notification);
+    }
+
+    public void deleteNotification(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(NOTIFICATION_NOT_FOUND, notificationId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND, userId));
+        if (!notification.getUser().equals(user))
+            throw new CustomException(UNAUTHORIZED_ACCESS);
+
+        notificationRepository.delete(notification);
     }
 }

--- a/src/main/java/hexfive/ismedi/notification/dto/NotificationDto.java
+++ b/src/main/java/hexfive/ismedi/notification/dto/NotificationDto.java
@@ -1,11 +1,12 @@
 package hexfive.ismedi.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.Date;
+import java.time.LocalTime;
 
 @Getter
 @Builder
@@ -16,6 +17,6 @@ public class NotificationDto {
     private String name;
 
     @NotNull(message = "알림 시간은 null일 수 없습니다.")
-    @NotBlank(message = "알림 시간은 필수입니다.")
-    private Date time;
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime time;
 }

--- a/src/main/java/hexfive/ismedi/notification/dto/NotificationDto.java
+++ b/src/main/java/hexfive/ismedi/notification/dto/NotificationDto.java
@@ -1,6 +1,7 @@
 package hexfive.ismedi.notification.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -18,5 +19,6 @@ public class NotificationDto {
 
     @NotNull(message = "알림 시간은 null일 수 없습니다.")
     @JsonFormat(pattern = "HH:mm")
+    @Schema(description = "알림 시간 (HH:mm 형식)", example = "09:30", type = "string")
     private LocalTime time;
 }

--- a/src/main/java/hexfive/ismedi/notification/dto/NotificationDto.java
+++ b/src/main/java/hexfive/ismedi/notification/dto/NotificationDto.java
@@ -1,0 +1,21 @@
+package hexfive.ismedi.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@Builder
+public class NotificationDto {
+
+    @NotNull(message = "알림 이름은 null일 수 없습니다.")
+    @NotBlank(message = "알림 이름은 필수입니다.")
+    private String name;
+
+    @NotNull(message = "알림 시간은 null일 수 없습니다.")
+    @NotBlank(message = "알림 시간은 필수입니다.")
+    private Date time;
+}

--- a/src/main/java/hexfive/ismedi/notification/dto/ResNotificationDto.java
+++ b/src/main/java/hexfive/ismedi/notification/dto/ResNotificationDto.java
@@ -1,0 +1,27 @@
+package hexfive.ismedi.notification.dto;
+
+import hexfive.ismedi.notification.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResNotificationDto {
+    private Long id;
+    private String name;
+    private Date time;
+
+    public static ResNotificationDto fromEntity(Notification notification) {
+        return ResNotificationDto.builder()
+                .id(notification.getId())
+                .name(notification.getName())
+                .time(notification.getTime())
+                .build();
+    }
+}

--- a/src/main/java/hexfive/ismedi/notification/dto/ResNotificationDto.java
+++ b/src/main/java/hexfive/ismedi/notification/dto/ResNotificationDto.java
@@ -1,6 +1,8 @@
 package hexfive.ismedi.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import hexfive.ismedi.notification.Notification;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +16,11 @@ import java.time.LocalTime;
 @Builder
 public class ResNotificationDto {
     private Long id;
+
     private String name;
+
+    @JsonFormat(pattern = "HH:mm")
+    @Schema(description = "알림 시간 (HH:mm 형식)", example = "09:30", type = "string")
     private LocalTime time;
 
     public static ResNotificationDto fromEntity(Notification notification) {

--- a/src/main/java/hexfive/ismedi/notification/dto/ResNotificationDto.java
+++ b/src/main/java/hexfive/ismedi/notification/dto/ResNotificationDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
@@ -15,7 +15,7 @@ import java.util.Date;
 public class ResNotificationDto {
     private Long id;
     private String name;
-    private Date time;
+    private LocalTime time;
 
     public static ResNotificationDto fromEntity(Notification notification) {
         return ResNotificationDto.builder()

--- a/src/main/java/hexfive/ismedi/oauth/AuthController.java
+++ b/src/main/java/hexfive/ismedi/oauth/AuthController.java
@@ -2,9 +2,8 @@ package hexfive.ismedi.oauth;
 
 import hexfive.ismedi.global.response.APIResponse;
 import hexfive.ismedi.global.exception.CustomException;
-import hexfive.ismedi.global.swagger.AuthControllerDocs;
+import hexfive.ismedi.global.swagger.AuthDocs;
 import hexfive.ismedi.jwt.TokenDto;
-import hexfive.ismedi.oauth.dto.KakaoUserInfoDto;
 import hexfive.ismedi.oauth.dto.SignupRequestDto;
 import hexfive.ismedi.users.dto.KaKaoLoginResultDto;
 import io.jsonwebtoken.JwtException;
@@ -23,7 +22,7 @@ import static hexfive.ismedi.global.exception.ErrorCode.*;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/auth")
-public class AuthController implements AuthControllerDocs {
+public class AuthController implements AuthDocs {
     private final AuthService authService;
 
     @Value("${kakao.client-id}")


### PR DESCRIPTION
## 📝 기능 설명
알림을 생성, 수정, 조회하는 기능을 구현하였습니다
알림을 실제로 보내기 위한 부분은 추후에 추가하도록 하겠습니다.

## 🛠 작업 사항
간단한 CRUD 구현만 하였습니다
로그인 후 사용가능한 기능이기 때문에 `@AuthenticationPrincipal`로 사용자의 아이디를 받아오도록 하였습니다.
컨트롤러 단에서 username인 id를 Long으로 파싱하고, 서비스 단에서 사용자에 대한 예외처리를 진행하는데 이 로직을 추후에 별도로 분리하면 더 좋을 것 같습니다
우선은 빨리 작업을 해야하니 이렇게 구현하였습니다,,,

## ✅ 작업 체크리스트
- [x] 알림 CRUD
- [x] swagger 작성

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
