### PR TITLE
즐겨찾기 등록, 삭제, 조회

### DIFF
--- a/src/main/java/hexfive/ismedi/domain/User.java
+++ b/src/main/java/hexfive/ismedi/domain/User.java
@@ -1,5 +1,6 @@
 package hexfive.ismedi.domain;
 
+import hexfive.ismedi.favorites.Favorite;
 import hexfive.ismedi.notification.Notification;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/hexfive/ismedi/favorites/Favorite.java
+++ b/src/main/java/hexfive/ismedi/favorites/Favorite.java
@@ -1,9 +1,18 @@
-package hexfive.ismedi.domain;
+package hexfive.ismedi.favorites;
 
+import hexfive.ismedi.domain.User;
 import hexfive.ismedi.medicine.Medicine;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "Favorite")
 public class Favorite {
     @Id

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
@@ -2,6 +2,7 @@ package hexfive.ismedi.favorites;
 
 import hexfive.ismedi.favorites.dto.ResFavoriteDto;
 import hexfive.ismedi.global.response.APIResponse;
+import hexfive.ismedi.global.swagger.FavoriteDocs;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,7 +13,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/favorites")
 @RequiredArgsConstructor
-public class FavoriteController {
+public class FavoriteController implements FavoriteDocs {
     private final FavoriteService favoriteService;
 
     @PostMapping("/{medicine-id}")

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
@@ -25,7 +25,7 @@ public class FavoriteController {
     @GetMapping
     public APIResponse<List<ResFavoriteDto>> getAllFavorites(@AuthenticationPrincipal UserDetails userDetails){
         Long userId = Long.parseLong(userDetails.getUsername());
-        return APIResponse.success(favoriteService.getFavoriteById(userId));
+        return APIResponse.success(favoriteService.getFavoriteByUserId(userId));
     }
 
     @DeleteMapping("/{medicine-id}")

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
@@ -35,4 +35,11 @@ public class FavoriteController implements FavoriteDocs {
         favoriteService.removeFavorite(userId, medicineId);
         return APIResponse.success("즐겨찾기에서 삭제되었습니다.");
     }
+
+    @DeleteMapping
+    public APIResponse<String> deleteAllFavorites(@AuthenticationPrincipal UserDetails userDetails){
+        Long userId = Long.parseLong(userDetails.getUsername());
+        favoriteService.removeAllFavorites(userId);
+        return APIResponse.success("즐겨찾기 목록이 전부 삭제되었습니다.");
+    }
 }

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteController.java
@@ -1,0 +1,37 @@
+package hexfive.ismedi.favorites;
+
+import hexfive.ismedi.favorites.dto.ResFavoriteDto;
+import hexfive.ismedi.global.response.APIResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/favorites")
+@RequiredArgsConstructor
+public class FavoriteController {
+    private final FavoriteService favoriteService;
+
+    @PostMapping("/{medicine-id}")
+    public APIResponse<String> createFavorites(@PathVariable("medicine-id") Long medicineId, @AuthenticationPrincipal UserDetails userDetails){
+        Long userId = Long.parseLong(userDetails.getUsername());
+        favoriteService.addFavorite(userId, medicineId);
+        return APIResponse.success("즐겨찾기에 등록되었습니다.");
+    }
+
+    @GetMapping
+    public APIResponse<List<ResFavoriteDto>> getAllFavorites(@AuthenticationPrincipal UserDetails userDetails){
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return APIResponse.success(favoriteService.getFavoriteById(userId));
+    }
+
+    @DeleteMapping("/{medicine-id}")
+    public APIResponse<String> deleteFavorites(@PathVariable("medicine-id") Long medicineId, @AuthenticationPrincipal UserDetails userDetails){
+        Long userId = Long.parseLong(userDetails.getUsername());
+        favoriteService.removeFavorite(userId, medicineId);
+        return APIResponse.success("즐겨찾기에서 삭제되었습니다.");
+    }
+}

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteRepository.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteRepository.java
@@ -1,0 +1,13 @@
+package hexfive.ismedi.favorites;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    List<Favorite> findByUserId(Long userId);
+    boolean existsByUserIdAndMedicineId(Long userId, Long medicineId);
+    Optional<Favorite> findByUserIdAndMedicineId(Long userId, Long medicineId);
+
+}

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
@@ -3,7 +3,6 @@ package hexfive.ismedi.favorites;
 import hexfive.ismedi.domain.User;
 import hexfive.ismedi.favorites.dto.ResFavoriteDto;
 import hexfive.ismedi.global.exception.CustomException;
-import hexfive.ismedi.global.exception.ErrorCode;
 import hexfive.ismedi.medicine.Medicine;
 import hexfive.ismedi.medicine.MedicineRepository;
 import hexfive.ismedi.users.UserRepository;
@@ -15,7 +14,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static hexfive.ismedi.global.exception.ErrorCode.FAVORITE_ALREADY_EXISTS;
 import static hexfive.ismedi.global.exception.ErrorCode.USER_NOT_FOUND;
+import static hexfive.ismedi.global.exception.ErrorCode.MEDICINE_NOT_FOUND;
+import static hexfive.ismedi.global.exception.ErrorCode.FAVORITE_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -27,13 +29,13 @@ public class FavoriteService {
     public void addFavorite(Long userId, Long medicineId) {
         boolean exists = favoriteRepository.existsByUserIdAndMedicineId(userId, medicineId);
         if (exists) {
-            throw new IllegalStateException("이미 즐겨찾기된 약입니다.");
+            throw new CustomException(FAVORITE_ALREADY_EXISTS);
         }
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         Medicine medicine = medicineRepository.findById(medicineId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 약을 찾을 수 없습니다"));
+                .orElseThrow(() -> new CustomException(MEDICINE_NOT_FOUND));
 
         Favorite favorite = Favorite.builder()
                 .user(user)
@@ -54,7 +56,7 @@ public class FavoriteService {
     @Transactional
     public void removeFavorite(Long userId, Long medicineId){
         Favorite favorite = favoriteRepository.findByUserIdAndMedicineId(userId, medicineId)
-                .orElseThrow(() -> new IllegalArgumentException("즐겨찾기 내역이 없습니다."));
+                .orElseThrow(() -> new CustomException(FAVORITE_NOT_FOUND));
         favoriteRepository.delete(favorite);
     }
 }

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
@@ -45,7 +45,7 @@ public class FavoriteService {
         favoriteRepository.save(favorite);
     }
 
-    public List<ResFavoriteDto> getFavoriteById(Long userId){
+    public List<ResFavoriteDto> getFavoriteByUserId(Long userId){
         List<Favorite> favorites = favoriteRepository.findByUserId(userId);
         if (favorites.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
@@ -1,0 +1,60 @@
+package hexfive.ismedi.favorites;
+
+import hexfive.ismedi.domain.User;
+import hexfive.ismedi.favorites.dto.ResFavoriteDto;
+import hexfive.ismedi.global.exception.CustomException;
+import hexfive.ismedi.global.exception.ErrorCode;
+import hexfive.ismedi.medicine.Medicine;
+import hexfive.ismedi.medicine.MedicineRepository;
+import hexfive.ismedi.users.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static hexfive.ismedi.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final MedicineRepository medicineRepository;
+
+    public void addFavorite(Long userId, Long medicineId) {
+        boolean exists = favoriteRepository.existsByUserIdAndMedicineId(userId, medicineId);
+        if (exists) {
+            throw new IllegalStateException("이미 즐겨찾기된 약입니다.");
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Medicine medicine = medicineRepository.findById(medicineId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약을 찾을 수 없습니다"));
+
+        Favorite favorite = Favorite.builder()
+                .user(user)
+                .medicine(medicine)
+                .build();
+
+        favoriteRepository.save(favorite);
+    }
+
+    public List<ResFavoriteDto> getFavoriteById(Long userId){
+        List<Favorite> favorites = favoriteRepository.findByUserId(userId);
+        if (favorites.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return favorites.stream().map(ResFavoriteDto::fromEntity).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void removeFavorite(Long userId, Long medicineId){
+        Favorite favorite = favoriteRepository.findByUserIdAndMedicineId(userId, medicineId)
+                .orElseThrow(() -> new IllegalArgumentException("즐겨찾기 내역이 없습니다."));
+        favoriteRepository.delete(favorite);
+    }
+}

--- a/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
+++ b/src/main/java/hexfive/ismedi/favorites/FavoriteService.java
@@ -59,4 +59,13 @@ public class FavoriteService {
                 .orElseThrow(() -> new CustomException(FAVORITE_NOT_FOUND));
         favoriteRepository.delete(favorite);
     }
+
+    @Transactional
+    public void removeAllFavorites(Long userId){
+        List<Favorite> favorites = favoriteRepository.findByUserId(userId);
+        if (favorites.isEmpty()) {
+            return;
+        }
+        favoriteRepository.deleteAll(favorites);
+    }
 }

--- a/src/main/java/hexfive/ismedi/favorites/dto/ResFavoriteDto.java
+++ b/src/main/java/hexfive/ismedi/favorites/dto/ResFavoriteDto.java
@@ -1,0 +1,20 @@
+package hexfive.ismedi.favorites.dto;
+
+import hexfive.ismedi.favorites.Favorite;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ResFavoriteDto {
+
+    private Long medicineId;
+    private String medicineName;
+
+    public static ResFavoriteDto fromEntity(Favorite favorite) {
+        return ResFavoriteDto.builder()
+                .medicineId(favorite.getMedicine().getId())
+                .medicineName(favorite.getMedicine().getItemName())
+                .build();
+    }
+}

--- a/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
+++ b/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
@@ -2,9 +2,6 @@ package hexfive.ismedi.global.exception;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.ErrorResponse;
-
-import java.util.Map;
 
 @Getter
 public enum ErrorCode {
@@ -42,6 +39,13 @@ public enum ErrorCode {
 
     // Notification
     NOTIFICATION_NOT_FOUND("CATEGORY_NOT_FOUND", "알림(id=%d)를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
+    // Favorite
+    FAVORITE_ALREADY_EXISTS("FAVORITE_ALREADY_EXISTS", "이미 즐겨찾기된 약입니다.", HttpStatus.CONFLICT),
+    FAVORITE_NOT_FOUND("FAVORITE_NOT_FOUND", "즐겨찾기 내역이 없습니다.", HttpStatus.NOT_FOUND),
+
+    // Medicine
+    MEDICINE_NOT_FOUND("MEDICINE_NOT_FOUND", "해당 약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 기타
     INTERNAL_ERROR("INTERNAL_ERROR", "서버 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
+++ b/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
     // Favorite
     FAVORITE_ALREADY_EXISTS("FAVORITE_ALREADY_EXISTS", "이미 즐겨찾기된 약입니다.", HttpStatus.CONFLICT),
     FAVORITE_NOT_FOUND("FAVORITE_NOT_FOUND", "즐겨찾기 내역이 없습니다.", HttpStatus.NOT_FOUND),
+
+    // Medicine
     MEDICINE_NOT_FOUND("MEDICINE_NOT_FOUND", "해당 약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 기타

--- a/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
+++ b/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
@@ -44,6 +44,11 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND("CATEGORY_NOT_FOUND", "사용자(id=%d)를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
 
+    // Favorite
+    FAVORITE_ALREADY_EXISTS("FAVORITE_ALREADY_EXISTS", "이미 즐겨찾기된 약입니다.", HttpStatus.CONFLICT),
+    FAVORITE_NOT_FOUND("FAVORITE_NOT_FOUND", "즐겨찾기 내역이 없습니다.", HttpStatus.NOT_FOUND),
+    MEDICINE_NOT_FOUND("MEDICINE_NOT_FOUND", "해당 약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
     // 기타
     INTERNAL_ERROR("INTERNAL_ERROR", "서버 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/hexfive/ismedi/global/swagger/FavoriteDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/FavoriteDocs.java
@@ -1,0 +1,28 @@
+package hexfive.ismedi.global.swagger;
+
+import hexfive.ismedi.favorites.dto.ResFavoriteDto;
+import hexfive.ismedi.global.response.APIResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+public interface FavoriteDocs {
+
+    @Operation(summary = "즐겨찾기 등록", description = "의약품 ID를 기반으로 해당 의약품을 현재 사용자 즐겨찾기에 추가합니다.")
+    APIResponse<String> createFavorites(
+            @PathVariable("medicine-id") Long medicineId,
+            @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "즐겨찾기 전체 조회", description = "현재 로그인한 사용자의 즐겨찾기 목록을 조회합니다.")
+    APIResponse<List<ResFavoriteDto>> getAllFavorites(@AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "즐겨찾기 삭제", description = "해당 의약품을 즐겨찾기에서 삭제합니다.")
+    APIResponse<String> deleteFavorites(@PathVariable("medicine-id") Long medicineId, @AuthenticationPrincipal UserDetails userDetails);
+}

--- a/src/main/java/hexfive/ismedi/global/swagger/FavoriteDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/FavoriteDocs.java
@@ -18,11 +18,17 @@ public interface FavoriteDocs {
     @Operation(summary = "즐겨찾기 등록", description = "의약품 ID를 기반으로 해당 의약품을 현재 사용자 즐겨찾기에 추가합니다.")
     APIResponse<String> createFavorites(
             @PathVariable("medicine-id") Long medicineId,
-            @AuthenticationPrincipal UserDetails userDetails);
+            @Parameter(hidden = true) UserDetails userDetails
+    );
 
     @Operation(summary = "즐겨찾기 전체 조회", description = "현재 로그인한 사용자의 즐겨찾기 목록을 조회합니다.")
-    APIResponse<List<ResFavoriteDto>> getAllFavorites(@AuthenticationPrincipal UserDetails userDetails);
+    APIResponse<List<ResFavoriteDto>> getAllFavorites(
+            @Parameter(hidden = true) UserDetails userDetails
+    );
 
     @Operation(summary = "즐겨찾기 삭제", description = "해당 의약품을 즐겨찾기에서 삭제합니다.")
-    APIResponse<String> deleteFavorites(@PathVariable("medicine-id") Long medicineId, @AuthenticationPrincipal UserDetails userDetails);
+    APIResponse<String> deleteFavorites(
+            @PathVariable("medicine-id") Long medicineId,
+            @Parameter(hidden = true) UserDetails userDetails
+    );
 }

--- a/src/main/java/hexfive/ismedi/global/swagger/FavoriteDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/FavoriteDocs.java
@@ -31,4 +31,9 @@ public interface FavoriteDocs {
             @PathVariable("medicine-id") Long medicineId,
             @Parameter(hidden = true) UserDetails userDetails
     );
+
+    @Operation(summary = "즐겨찾기 전체 삭제", description = "해당 사용자의 즐겨찾기 목록을 전부 삭제합니다.")
+    APIResponse<String> deleteAllFavorites(
+            @Parameter(hidden = true) UserDetails userDetails
+    );
 }


### PR DESCRIPTION
close #28 
## 📝 기능 설명
즐겨찾기 등록, 삭제, 조회 기능 추가하였습니다.

## 🛠 작업 사항
즐겨찾기 등록, 조회, 단일 삭제, 전체 삭제 기능입니다. 
사용자 탈퇴 처리할 때 전체 삭제 api도 필요할 것 같아 추가해두었습니다.
그리고 즐겨찾기 목록 조회할 때 medicineId, medicineName만 응답하도록 했습니다. 혹시 추가 정보가 필요하다면 추후 반영하겠습니다!
![image](https://github.com/user-attachments/assets/f32d65f8-80c9-4249-91cc-ace6afe66510)


## ✅ 작업 체크리스트
- [x] Swagger 문서화

## 📎 참고 자료
