### PR TITLE
#31 푸시 알림 전송 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 ### Secret Properties ###
 *.properties
 !gradle/wrapper/gradle-wrapper.properties
+firebaseKye.json

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	
   // Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// Firebase
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/hexfive/ismedi/domain/User.java
+++ b/src/main/java/hexfive/ismedi/domain/User.java
@@ -47,6 +47,9 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Notification> notifications;
 
+    @Column(nullable = true)
+    private String fcmToken;
+
     public enum Gender {
         WOMAN,
         MAN;
@@ -57,5 +60,9 @@ public class User {
         this.gender = gender;
         this.pregnant = pregnant;
         this.alert = alert;
+    }
+
+    public void setFCMToken(String token) {
+        this.fcmToken = token;
     }
 }

--- a/src/main/java/hexfive/ismedi/global/config/FirebaseConfig.java
+++ b/src/main/java/hexfive/ismedi/global/config/FirebaseConfig.java
@@ -1,0 +1,32 @@
+package hexfive.ismedi.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            FileInputStream serviceAccount =
+                    new FileInputStream("src/main/resources/firebaseKey.json");
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Firebase 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/hexfive/ismedi/global/swagger/UserDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/UserDocs.java
@@ -1,6 +1,7 @@
 package hexfive.ismedi.global.swagger;
 
 import hexfive.ismedi.global.response.APIResponse;
+import hexfive.ismedi.users.dto.FCMTokenRequestDto;
 import hexfive.ismedi.users.dto.UpdateRequestDto;
 import hexfive.ismedi.users.dto.UserResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,5 +53,20 @@ public interface UserDocs {
     APIResponse<?> deleteUserInfo(
             @Parameter(description = "삭제할 사용자 ID", example = "10") @PathVariable Long id,
             @AuthenticationPrincipal UserDetails userDetails
+    );
+
+
+    @Operation(
+            summary = "FCM 토큰 등록",
+            description = "모바일 앱에서 발급된 FCM 토큰을 서버에 등록합니다. 이 토큰을 통해 서버가 푸시 알림을 전송할 수 있습니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 등록 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 ID")
+    })
+    @PostMapping("/fcm-token")
+    APIResponse<Void> getToken(
+            @AuthenticationPrincipal @Parameter(hidden = true) UserDetails userDetails,
+            @RequestBody FCMTokenRequestDto fcmtokenRequestDto
     );
 }

--- a/src/main/java/hexfive/ismedi/notification/NotificationRepository.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationRepository.java
@@ -3,9 +3,11 @@ package hexfive.ismedi.notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalTime;
 import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByUserId(Long userId);
+    List<Notification> findByTime(LocalTime time);
 }

--- a/src/main/java/hexfive/ismedi/notification/NotificationService.java
+++ b/src/main/java/hexfive/ismedi/notification/NotificationService.java
@@ -1,5 +1,7 @@
 package hexfive.ismedi.notification;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
 import hexfive.ismedi.category.Category;
 import hexfive.ismedi.domain.User;
 import hexfive.ismedi.global.exception.CustomException;
@@ -8,14 +10,20 @@ import hexfive.ismedi.notification.dto.ResNotificationDto;
 import hexfive.ismedi.users.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import static hexfive.ismedi.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@EnableScheduling
 @Slf4j
 public class NotificationService {
     private final NotificationRepository notificationRepository;
@@ -78,5 +86,45 @@ public class NotificationService {
             throw new CustomException(UNAUTHORIZED_ACCESS);
 
         notificationRepository.delete(notification);
+    }
+
+    private void sendNotification(Notification notification) {
+        String token = notification.getUser().getFcmToken();
+        if (token == null || token.isBlank()) {
+            // 토큰이 없을 경우 처리
+            log.warn("FCM 토큰이 존재하지 않습니다. 사용자 ID: {}", notification.getUser().getId());
+            return;
+        }
+
+        String title = "복약 알림";
+        String formattedTime = notification.getTime()
+                .format(DateTimeFormatter.ofPattern("a h:mm").withLocale(Locale.KOREAN));
+        String body = String.format("지금은 [%s] 복용 시간입니다 (%s). 잊지 말고 챙겨 드세요!", notification.getName(), formattedTime);
+
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(com.google.firebase.messaging.Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("알림 메시지 전송 성공: {}", response);
+        } catch (Exception e) {
+            log.error("FCM 메시지 전송 실패", e);
+        }
+    }
+
+//    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(fixedRate = 60000) // 60,000ms = 1분
+    public void sendScheduledNotifications() {
+        LocalTime currentTime = LocalTime.now().withSecond(0).withNano(0); // 초 단위는 무시한 현재 시간
+        log.info(String.valueOf(currentTime));
+        List<Notification> notifications = notificationRepository.findByTime(currentTime);
+        for (Notification notification : notifications) {
+            sendNotification(notification);
+        }
     }
 }

--- a/src/main/java/hexfive/ismedi/users/UserController.java
+++ b/src/main/java/hexfive/ismedi/users/UserController.java
@@ -3,6 +3,7 @@ package hexfive.ismedi.users;
 
 import hexfive.ismedi.global.response.APIResponse;
 import hexfive.ismedi.global.swagger.UserDocs;
+import hexfive.ismedi.users.dto.FCMTokenRequestDto;
 import hexfive.ismedi.users.dto.UpdateRequestDto;
 import hexfive.ismedi.users.dto.UserResponseDto;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -47,6 +48,16 @@ public class UserController implements UserDocs {
     ){
         Long loginUserId = Long.parseLong(userDetails.getUsername());
         userService.deleteUserInfo(loginUserId, id);
+        return APIResponse.success(null);
+    }
+
+    @PostMapping("/fcm-token")
+    public APIResponse<Void> getToken(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody FCMTokenRequestDto fcmtokenRequestDto
+    ){
+        Long userId = Long.parseLong(userDetails.getUsername());
+        userService.getFCMToken(userId, fcmtokenRequestDto);
         return APIResponse.success(null);
     }
 }

--- a/src/main/java/hexfive/ismedi/users/UserService.java
+++ b/src/main/java/hexfive/ismedi/users/UserService.java
@@ -2,6 +2,7 @@ package hexfive.ismedi.users;
 
 import hexfive.ismedi.domain.User;
 import hexfive.ismedi.global.exception.CustomException;
+import hexfive.ismedi.users.dto.FCMTokenRequestDto;
 import hexfive.ismedi.users.dto.UpdateRequestDto;
 import hexfive.ismedi.users.dto.UserResponseDto;
 import jakarta.transaction.Transactional;
@@ -49,5 +50,12 @@ public class UserService {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         userRepository.delete(user);
+    }
+
+    public void getFCMToken(Long userId, FCMTokenRequestDto fcmTokenRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        user.setFCMToken(fcmTokenRequestDto.getFcmToken());
+        userRepository.save(user);
     }
 }

--- a/src/main/java/hexfive/ismedi/users/dto/FCMTokenRequestDto.java
+++ b/src/main/java/hexfive/ismedi/users/dto/FCMTokenRequestDto.java
@@ -1,0 +1,8 @@
+package hexfive.ismedi.users.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FCMTokenRequestDto {
+    private String fcmToken;
+}


### PR DESCRIPTION
close #31 

## 📝 기능 설명
매 분마다 설정된 알림들을 확인하여 전송하는 기능을 구현하였습니다

## 🛠 작업 사항
사용자의 디바이스를 식별할 수 있는 fcm 토큰을 프론트로부터 받아 저장하는 api를 구현하였습니다.
알림을 전송할 firebase 서버를 만들어서 연동하였고, 알림을 전송하는 로직을 구현하였습니다.

## ✅ 작업 체크리스트
- [x] fcm 토큰 저장 api 구현
- [x] firebase와 연동
- [x] 알림 전송 로직 구현
- [ ] 프론트와 연동 여부 확인 및 수정

## 📎 참고 자료
매 분마다 cron이 동작하고, 해당 시간에 알림 전송 로직이 동작하는 것까지 확인하였습니다.
등록한 알림 시간에 전송 로직이 실행되고, 디바이스를 확인할 수 있는 fcm 토큰이 정상적이지 않다는 응답을 받은 모습입니다.
이후 로직의 정상 작동 여부는 프론트와 연동 후에 확인 가능할 것 같습니다.

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/2a498f88-3d9d-47bf-ad31-1d84baf7e192" />
