### PR TITLE
#31 FirebaseConfig 환경 설정 추가

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -39,6 +39,10 @@ jobs:
           mkdir -p ./config
           echo "${{ secrets.APPLICATION_PROPERTIES_CONTENT }}" > ./config/application.properties
 
+      - name: firebaseKey.json 생성
+        run: |
+          echo "${{ secrets.FIREBASE_KEY_CONTENT }}" > ./config/firebaseKey.json
+
       - name: .env 생성
         run: |
           echo "${{ secrets.DOCKER_ENV }}" > ./.env

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 ### Secret Properties ###
 *.properties
 !gradle/wrapper/gradle-wrapper.properties
-firebaseKye.json
+firebaseKey.json

--- a/src/main/java/hexfive/ismedi/global/config/FirebaseConfig.java
+++ b/src/main/java/hexfive/ismedi/global/config/FirebaseConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.FileInputStream;
@@ -11,12 +12,14 @@ import java.io.IOException;
 
 @Configuration
 public class FirebaseConfig {
+    @Value("${firebase.key.path}")
+    private String firebaseKeyPath;
 
     @PostConstruct
     public void initialize() {
         try {
             FileInputStream serviceAccount =
-                    new FileInputStream("src/main/resources/firebaseKey.json");
+                    new FileInputStream(firebaseKeyPath);
 
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))


### PR DESCRIPTION
## 📝 기능 설명
배포 환경에 firebaseKey가 등록되지 않아서 발생하는 오류를 해결하였습니다. 

## 🛠 작업 사항
firebaseKey 의 경로를 환경변수로 분리하여 application.properties 파일에서 관리할 수 있도록 하였습니다.

## ✅ 작업 체크리스트
- [x] APPLICATION_PROPERTIES_CONTENT 환경변수 업데이트
- [x] FIREBASE_KEY_CONTENT 환경변수 생성
- [x] CICD firebaseKey.json 로직 추가

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
