### PR TITLE
약 데이터베이스 구축 로직 변경

### DIFF
--- a/src/main/java/hexfive/ismedi/medicine/MedicineService.java
+++ b/src/main/java/hexfive/ismedi/medicine/MedicineService.java
@@ -1,7 +1,8 @@
 package hexfive.ismedi.medicine;
 
 import hexfive.ismedi.global.exception.CustomException;
-import hexfive.ismedi.global.exception.ErrorCode;
+import hexfive.ismedi.medicine.dto.DURInteractionDto;
+import hexfive.ismedi.medicine.dto.ResInteractionDto;
 import hexfive.ismedi.medicine.dto.ResMedicineDetailDto;
 import hexfive.ismedi.medicine.dto.ResMedicineDto;
 import hexfive.ismedi.openApi.APIType;
@@ -13,7 +14,6 @@ import hexfive.ismedi.openApi.data.prescriptionType.PrescriptionTypeRepository;
 import hexfive.ismedi.openApi.dto.OpenAPIResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.util.*;

--- a/src/main/java/hexfive/ismedi/medicine/MedicineService.java
+++ b/src/main/java/hexfive/ismedi/medicine/MedicineService.java
@@ -1,5 +1,7 @@
 package hexfive.ismedi.medicine;
 
+import hexfive.ismedi.global.exception.CustomException;
+import hexfive.ismedi.global.exception.ErrorCode;
 import hexfive.ismedi.medicine.dto.ResMedicineDetailDto;
 import hexfive.ismedi.medicine.dto.ResMedicineDto;
 import hexfive.ismedi.openApi.data.drugInfo.DrugInfo;
@@ -8,6 +10,7 @@ import hexfive.ismedi.openApi.data.drugInfo.DrugInfoRepository;
 import hexfive.ismedi.openApi.data.prescriptionType.PrescriptionTypeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -23,30 +26,32 @@ public class MedicineService {
     private final MedicineRepository medicineRepository;
 
     public void mergeToMedicineTable() {
-        List<DrugInfo> drugInfos = drugInfoRepository.findAll();
+        List<PrescriptionType> prescriptionTypes = prescriptionTypeRepository.findAll();
 
-        for (DrugInfo di : drugInfos) {
-            String itemSeq = di.getItemSeq();
-            Optional<PrescriptionType> optionalPresc = prescriptionTypeRepository.findByItemSeq(itemSeq);
+        for (PrescriptionType pt : prescriptionTypes) {
+            try {
+                String itemSeq = pt.getItemSeq();
+                DrugInfo di = drugInfoRepository.findByItemSeq(itemSeq).orElse(null);
 
-            optionalPresc.ifPresent(pt -> {
                 Medicine medicine = Medicine.builder()
                         .itemSeq(itemSeq)
                         .entpName(pt.getEntpName())
                         .itemName(pt.getItemName())
                         .etcOtcCodeName(pt.getEtcOtcCodeName())
                         .classNoName(pt.getClassNoName())
-                        .itemImage(di.getItemImage())
-                        .efcyQesitm(di.getEfcyQesitm())
-                        .useMethodQesitm(di.getUseMethodQesitm())
-                        .atpnQesitm(di.getAtpnQesitm())
-                        .intrcQesitm(di.getIntrcQesitm())
-                        .seQesitm(di.getSeQesitm())
-                        .depositMethodQesitm(di.getDepositMethodQesitm())
+                        .itemImage(di != null ? di.getItemImage() : null)
+                        .efcyQesitm(di != null ? di.getEfcyQesitm() : null)
+                        .useMethodQesitm(di != null ? di.getUseMethodQesitm() : null)
+                        .atpnQesitm(di != null ? di.getAtpnQesitm() : null)
+                        .intrcQesitm(di != null ? di.getIntrcQesitm() : null)
+                        .seQesitm(di != null ? di.getSeQesitm() : null)
+                        .depositMethodQesitm(di != null ? di.getDepositMethodQesitm() : null)
                         .build();
 
                 medicineRepository.save(medicine);
-            });
+            } catch (Exception e) {
+                log.warn("itemSeq={} 약 데이터 저장 실패 : {}", pt.getItemSeq(), e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/hexfive/ismedi/openApi/data/drugInfo/DrugInfoRepository.java
+++ b/src/main/java/hexfive/ismedi/openApi/data/drugInfo/DrugInfoRepository.java
@@ -1,9 +1,13 @@
 package hexfive.ismedi.openApi.data.drugInfo;
 
+import hexfive.ismedi.openApi.data.prescriptionType.PrescriptionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface DrugInfoRepository extends JpaRepository<DrugInfo, String> {
     boolean existsByItemSeq(String itemSeq);
+    Optional<DrugInfo> findByItemSeq(String itemSeq);
 }


### PR DESCRIPTION
## 📝 기능 설명
세부 정보까지 제공하던 API로 조회 가능한 약들로만 데이터베이스를 구축하였더니
- AI로 분류 가능한 약 목록과 일치하는 약이 존재하지 않음
- 병용금기 여부를 확인할 수 있는 약이 무엇인지 알 수 없음
위의 두가지 이유로 약 이름, 제조업체, 약 품목분류(제산제, 항히스타민제 등), 의약품 분류(전문/일반)만 제공하는 약 또한 medicine 테이블에 추가하여 사용할 수 있도록 하였습니다.
해당 약들의 세부 정보를 제공할 방안은 추후에 찾아보도록 하겠습니다... (AI 허브에서 제공하는 json파일을 활용하여 추가할 예정)

## 🛠 작업 사항
약 데이터베이스 구축 로직 변경
두가지 API 중 더 많은 약의 개수를 갖는 API를 기준으로 medicine 데이터베이스를 구축하였습니다.

## ✅ 작업 체크리스트
- [x] 약 데이터베이스 구축 로직 변경
- [x] AI 허브 데이터로 부족한 데이터 추가

## 📎 참고 자료
AI로 분류 가능한 약 목록의 이름을 기준으로 검색한 경우 한 가지 약 빼고 모두 검색 가능한 것을 확인하였습니다.
<img width="518" alt="image" src="https://github.com/user-attachments/assets/794c8b20-3d79-453d-b743-66552b061ba6" />
