### PR TITLE
AI 서버로 이미지 전송 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .DS_Store
+/uploads
 
 ### STS ###
 .apt_generated

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
@@ -1,4 +1,42 @@
 package hexfive.ismedi.fastApi;
 
+import hexfive.ismedi.fastApi.dto.AiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.file.Path;
+
+@Component
+@RequiredArgsConstructor
 public class FastApiClient {
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    public AiResponseDto sendImage(Path imagePath){
+        FileSystemResource imageResource = new FileSystemResource(imagePath);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("image", imageResource); // FastAPI에서 image 파라미터로 받아야 함
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        RestTemplate template = new RestTemplate();
+        ResponseEntity<AiResponseDto> response = template.postForEntity(
+                aiServerUrl + "/predict",
+                requestEntity,
+                AiResponseDto.class
+        );
+        return response.getBody();
+    }
+
 }

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
@@ -2,6 +2,7 @@ package hexfive.ismedi.fastApi;
 
 import hexfive.ismedi.fastApi.dto.AiResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
@@ -11,6 +12,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.file.Path;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -19,7 +21,7 @@ public class FastApiClient {
     @Value("${ai.server.url}")
     private String aiServerUrl;
 
-    public AiResponseDto sendImage(Path imagePath){
+    public List<AiResponseDto> sendImage(Path imagePath){
         FileSystemResource imageResource = new FileSystemResource(imagePath);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
@@ -31,10 +33,11 @@ public class FastApiClient {
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
         RestTemplate template = new RestTemplate();
-        ResponseEntity<AiResponseDto> response = template.postForEntity(
+        ResponseEntity<List<AiResponseDto>> response = template.exchange(
                 aiServerUrl + "/predict",
+                HttpMethod.POST,
                 requestEntity,
-                AiResponseDto.class
+                new ParameterizedTypeReference<List<AiResponseDto>>() {}
         );
         return response.getBody();
     }

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
@@ -1,0 +1,4 @@
+package hexfive.ismedi.fastApi;
+
+public class FastApiClient {
+}

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
@@ -2,6 +2,7 @@ package hexfive.ismedi.fastApi;
 
 import hexfive.ismedi.fastApi.dto.AiResponseDto;
 import hexfive.ismedi.global.response.APIResponse;
+import hexfive.ismedi.global.swagger.FastApiDocs;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/ai")
-public class FastApiController {
+public class FastApiController implements FastApiDocs {
     private final FastApiService fastApiService;
 
     @PostMapping(value = "/recognitions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
@@ -1,0 +1,23 @@
+package hexfive.ismedi.fastApi;
+
+import hexfive.ismedi.global.response.APIResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+public class FastApiController {
+    private final FastApiService fastApiService;
+
+    @PostMapping(value = "/recognitions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public APIResponse<?> recognition(@RequestParam("image") MultipartFile imageFile) {
+        String path = fastApiService.saveImage(imageFile);
+        return APIResponse.success(path);
+    }
+}

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
@@ -1,5 +1,6 @@
 package hexfive.ismedi.fastApi;
 
+import hexfive.ismedi.fastApi.dto.AiResponseDto;
 import hexfive.ismedi.global.response.APIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -16,8 +17,7 @@ public class FastApiController {
     private final FastApiService fastApiService;
 
     @PostMapping(value = "/recognitions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public APIResponse<?> recognition(@RequestParam("image") MultipartFile imageFile) {
-        String path = fastApiService.saveImage(imageFile);
-        return APIResponse.success(path);
+    public APIResponse<AiResponseDto> recognition(@RequestParam("image") MultipartFile imageFile) {
+        return APIResponse.success(fastApiService.recognize(imageFile));
     }
 }

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/ai")
@@ -18,7 +20,7 @@ public class FastApiController implements FastApiDocs {
     private final FastApiService fastApiService;
 
     @PostMapping(value = "/recognitions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public APIResponse<AiResponseDto> recognition(@RequestParam("image") MultipartFile imageFile) {
+    public APIResponse<List<AiResponseDto>> recognition(@RequestParam("image") MultipartFile imageFile) {
         return APIResponse.success(fastApiService.recognize(imageFile));
     }
 }

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
@@ -1,0 +1,40 @@
+package hexfive.ismedi.fastApi;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FastApiService {
+    public final String UPLOAD_DIR = "uploads/";
+
+    public String saveImage(MultipartFile imageFile) {
+        try{
+            Path uploadDir = Paths.get(UPLOAD_DIR);
+            if (!Files.exists(uploadDir)) {
+                Files.createDirectory(uploadDir);
+            }
+
+            String imageName = imageFile.getOriginalFilename();
+            String ext = "";
+            if(imageName != null && imageName.contains(".")){
+                ext = imageName.substring(imageName.lastIndexOf("."));
+            }
+
+            String savedFileName = UUID.randomUUID() + ext;
+            Path filePath = uploadDir.resolve(savedFileName);
+            imageFile.transferTo(filePath.toFile());
+
+            return filePath.toString();
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 저장 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.UUID;
 
 import static hexfive.ismedi.global.exception.ErrorCode.INTERNAL_ERROR;
@@ -20,11 +21,11 @@ public class FastApiService {
     public final FastApiClient fastApiClient;
     private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/"; // 톰캣 내장서버 기준 말고 현재 서버 기준으로
 
-    public AiResponseDto recognize(MultipartFile imageFile){
+    public List<AiResponseDto> recognize(MultipartFile imageFile){
         String path = saveImage(imageFile);
         Path imagePath = Paths.get(path);
         try{
-            AiResponseDto response = sendToAiServer(imagePath);
+            List<AiResponseDto> response = sendToAiServer(imagePath);
             deleteImage(imagePath);
             return response;
         } catch (Exception e){
@@ -57,7 +58,7 @@ public class FastApiService {
         }
     }
 
-    public AiResponseDto sendToAiServer(Path imagePath) {
+    public List<AiResponseDto> sendToAiServer(Path imagePath) {
         return fastApiClient.sendImage(imagePath);
     }
 

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AiResponseDto {
-    private String name;
+    private Long id;
     private double confidence;
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
@@ -1,0 +1,4 @@
+package hexfive.ismedi.fastApi.dto;
+
+public class AiResponseDto {
+}

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
@@ -1,4 +1,13 @@
 package hexfive.ismedi.fastApi.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class AiResponseDto {
+    private String name;
+    private double confidence;
 }

--- a/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
+++ b/src/main/java/hexfive/ismedi/global/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     // 요청 오류 관련
     VALIDATION_FAILED("VALIDATION_FAILED", "요청값이 유효하지 않습니다", HttpStatus.BAD_REQUEST),
     DUPLICATE_EMAIL("DUPLICATE_EMAIL", "이미 등록된 이메일입니다", HttpStatus.BAD_REQUEST),
+    MAX_FILE_SIZE_EXCEEDED("MAX_FILE_SIZE_EXCEEDED", "업로드 가능한 최대 파일 크기를 초과했습니다. (최대 5MB)", HttpStatus.BAD_REQUEST),
+
 
     // AI 관련
     AI_SERVER_ERROR("AI_SERVER_ERROR", "AI 서버와 통신할 수 없습니다", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/hexfive/ismedi/global/exception/IsMediExceptionHandler.java
+++ b/src/main/java/hexfive/ismedi/global/exception/IsMediExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -48,5 +49,12 @@ public class IsMediExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(APIResponse.fail(errorMessage));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<APIResponse<Void>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+        return ResponseEntity
+                .status(ErrorCode.MAX_FILE_SIZE_EXCEEDED.getStatus())
+                .body(APIResponse.fail(ErrorCode.MAX_FILE_SIZE_EXCEEDED.getMessage()));
     }
 }

--- a/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Tag(name = "FastAPI", description = "AI 약 이미지 분석 API")
 public interface FastApiDocs {
 
@@ -16,7 +18,7 @@ public interface FastApiDocs {
             description = "이미지 파일을 업로드하면 AI 모델을 통해 약 이름 및 추론 결과를 반환합니다."
     )
     @PostMapping(value = "/api/ai/recognitions", consumes = "multipart/form-data")
-    APIResponse<AiResponseDto> recognition(
+    APIResponse<List<AiResponseDto>> recognition(
             @RequestParam("image") MultipartFile imageFile
     );
 }

--- a/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
@@ -1,0 +1,22 @@
+package hexfive.ismedi.global.swagger;
+
+import hexfive.ismedi.fastApi.dto.AiResponseDto;
+import hexfive.ismedi.global.response.APIResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "FastAPI", description = "AI 약 이미지 분석 API")
+public interface FastApiDocs {
+
+    @Operation(
+            summary = "약 이미지 인식",
+            description = "이미지 파일을 업로드하면 AI 모델을 통해 약 이름 및 추론 결과를 반환합니다."
+    )
+    @PostMapping(value = "/api/ai/recognitions", consumes = "multipart/form-data")
+    APIResponse<AiResponseDto> recognition(
+            @RequestParam("image") MultipartFile imageFile
+    );
+}


### PR DESCRIPTION
close #37 
## 📝 기능 설명
프론트에서 이미지 받아서 서버에 저장하고, AI 서버에 이미지 전송하여 추론 결과 반환받는 흐름 구현했습니다. 

## 🛠 작업 사항
이미지는 일회성으로, AI 서버에 전송 후 응답 받으면 삭제해도 될 것 같아서 단순하게 스프링 서버에 저장하는 걸로 구현했습니다. 
현재 AI 서버가 아직 로컬에서 돌아가고 있어서, 로컬에서 간단한 FastAPI 테스트 서버 열고 테스트 해본 결과 이미지 원본 상태 그대로 잘 전달 되는 것 확인했고, 응답으로 추론 결과 상위 5개의 약 이름과 인식률을(일단 테스트에서는 더미 데이터) 각각 List로 받도록 했습니다.
![image](https://github.com/user-attachments/assets/75fb8706-69dc-4885-a54d-69470adadd51)

그리고 프론트에서 받는 이미지의 크기를 제한해야 할 것 같아서 우선 5MB로 제한해두었습니다. 혹시 이 용량 제한이 너무 적으면 8~10MB 까지 늘리는 것도 고려해보면 될 것 같습니다!
```
# AI server
ai.server.url=http://localhost:8000

# image file size
spring.servlet.multipart.max-file-size=5MB
```
![스크린샷 2025-05-15 161524](https://github.com/user-attachments/assets/e4bcb2c0-3904-4482-b8ba-ebfdb05d6bcd)



## ✅ 작업 체크리스트
- [x] 이미지 저장 후 AI 서버에 전송, 응답 반환
- [x] 전송 과정에서 이미지 변형/손실 없는지 확인
- [x] Swagger 문서화

## 📎 참고 자료
