### PR TITLE
AI 서버 연동 수정

### DIFF
--- a/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
@@ -49,15 +49,10 @@ public class FastApiClient {
             if(responseBody == null || !responseBody.isStatus()){
                 throw new CustomException(AI_SERVER_ERROR);
             }
-            if(!responseBody.isDetected() || responseBody.getData() == null){
-                return responseBody.getData();
-            }
 
             return responseBody.getData();
         }catch (Exception e){
-            e.printStackTrace();
             throw new CustomException(AI_SERVER_ERROR);
         }
     }
-
 }

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
@@ -46,7 +46,7 @@ public class FastApiClient {
             );
 
             AiResponseWrapperDto responseBody = response.getBody();
-            if(responseBody == null || !responseBody.isStatus()){
+            if(responseBody == null || !responseBody.isSuccess()){
                 throw new CustomException(AI_SERVER_ERROR);
             }
 

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
@@ -1,6 +1,7 @@
 package hexfive.ismedi.fastApi;
 
 import hexfive.ismedi.fastApi.dto.AiResponseDto;
+import hexfive.ismedi.fastApi.dto.ResAiMedicineDto;
 import hexfive.ismedi.global.response.APIResponse;
 import hexfive.ismedi.global.swagger.FastApiDocs;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class FastApiController implements FastApiDocs {
     private final FastApiService fastApiService;
 
     @PostMapping(value = "/recognitions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public APIResponse<AiResponseDto> recognition(@RequestParam("image") MultipartFile imageFile) {
+    public APIResponse<List<ResAiMedicineDto>> recognition(@RequestParam("image") MultipartFile imageFile) {
         return APIResponse.success(fastApiService.recognize(imageFile));
     }
 }

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiController.java
@@ -20,7 +20,7 @@ public class FastApiController implements FastApiDocs {
     private final FastApiService fastApiService;
 
     @PostMapping(value = "/recognitions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public APIResponse<List<AiResponseDto>> recognition(@RequestParam("image") MultipartFile imageFile) {
+    public APIResponse<AiResponseDto> recognition(@RequestParam("image") MultipartFile imageFile) {
         return APIResponse.success(fastApiService.recognize(imageFile));
     }
 }

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
@@ -21,11 +21,11 @@ public class FastApiService {
     public final FastApiClient fastApiClient;
     private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/"; // 톰캣 내장서버 기준 말고 현재 서버 기준으로
 
-    public List<AiResponseDto> recognize(MultipartFile imageFile){
+    public AiResponseDto recognize(MultipartFile imageFile){
         String path = saveImage(imageFile);
         Path imagePath = Paths.get(path);
         try{
-            List<AiResponseDto> response = sendToAiServer(imagePath);
+            AiResponseDto response = sendToAiServer(imagePath);
             deleteImage(imagePath);
             return response;
         } catch (Exception e){
@@ -58,7 +58,7 @@ public class FastApiService {
         }
     }
 
-    public List<AiResponseDto> sendToAiServer(Path imagePath) {
+    public AiResponseDto sendToAiServer(Path imagePath) {
         return fastApiClient.sendImage(imagePath);
     }
 

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
@@ -1,6 +1,7 @@
 package hexfive.ismedi.fastApi;
 
 import hexfive.ismedi.fastApi.dto.AiResponseDto;
+import hexfive.ismedi.fastApi.dto.ResAiMedicineDto;
 import hexfive.ismedi.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,11 +22,11 @@ public class FastApiService {
     public final FastApiClient fastApiClient;
     private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/"; // 톰캣 내장서버 기준 말고 현재 서버 기준으로
 
-    public AiResponseDto recognize(MultipartFile imageFile){
+    public List<ResAiMedicineDto> recognize(MultipartFile imageFile){
         String path = saveImage(imageFile);
         Path imagePath = Paths.get(path);
         try{
-            AiResponseDto response = sendToAiServer(imagePath);
+            List<ResAiMedicineDto> response = sendToAiServer(imagePath);
             deleteImage(imagePath);
             return response;
         } catch (Exception e){
@@ -58,7 +59,7 @@ public class FastApiService {
         }
     }
 
-    public AiResponseDto sendToAiServer(Path imagePath) {
+    public List<ResAiMedicineDto> sendToAiServer(Path imagePath) {
         return fastApiClient.sendImage(imagePath);
     }
 

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
@@ -7,8 +7,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class AiClassProbDto {
-    @JsonProperty("class")
+    @JsonProperty("class_id")
     private Long classId;
 
-    private double prob;
+    private double confidence;
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
@@ -1,0 +1,14 @@
+package hexfive.ismedi.fastApi.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AiClassProbDto {
+    @JsonProperty("class")
+    private String className;
+
+    private double prob;
+}

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 public class AiClassProbDto {
     @JsonProperty("class")
-    private String className;
+    private Long classId;
 
     private double prob;
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
@@ -1,5 +1,6 @@
 package hexfive.ismedi.fastApi.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,10 @@ import java.util.List;
 @AllArgsConstructor
 public class AiResponseDto {
     private List<Integer> box;
-    private Long top_class;
-    private double top_prob;
-    private List<AiClassProbDto> all_classes;
+
+    @JsonProperty("primary_prediction")
+    private AiClassProbDto primaryPrediction;
+
+    @JsonProperty("top_predictions")
+    private List<AiClassProbDto> topPredictions;
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @AllArgsConstructor
 public class AiResponseDto {
     private List<Integer> box;
-    private String top_class;
+    private Long top_class;
     private double top_prob;
     private List<AiClassProbDto> all_classes;
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseDto.java
@@ -4,10 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class AiResponseDto {
-    private Long id;
-    private double confidence;
+    private List<Integer> box;
+    private String top_class;
+    private double top_prob;
+    private List<AiClassProbDto> all_classes;
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseWrapperDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseWrapperDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AiResponseWrapperDto {
-    private boolean status;
+    private boolean success;
     private boolean detected;
     private AiResponseDto data;  // null일 수 있음
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseWrapperDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiResponseWrapperDto.java
@@ -1,0 +1,14 @@
+package hexfive.ismedi.fastApi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiResponseWrapperDto {
+    private boolean status;
+    private boolean detected;
+    private AiResponseDto data;  // null일 수 있음
+}

--- a/src/main/java/hexfive/ismedi/fastApi/dto/ResAiMedicineDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/ResAiMedicineDto.java
@@ -1,0 +1,25 @@
+package hexfive.ismedi.fastApi.dto;
+
+import hexfive.ismedi.medicine.dto.ResMedicineDetailDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResAiMedicineDto {
+    private ResMedicineDetailDto medicine;
+    private double confidence;
+
+    public static ResAiMedicineDto of(ResMedicineDetailDto detailDto, Double confidence) {
+        return ResAiMedicineDto.builder()
+                .medicine(detailDto)
+                .confidence(confidence)
+                .build();
+    }
+}

--- a/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
@@ -1,6 +1,7 @@
 package hexfive.ismedi.global.swagger;
 
 import hexfive.ismedi.fastApi.dto.AiResponseDto;
+import hexfive.ismedi.fastApi.dto.ResAiMedicineDto;
 import hexfive.ismedi.global.response.APIResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,7 +19,7 @@ public interface FastApiDocs {
             description = "이미지 파일을 업로드하면 AI 모델을 통해 약 이름 및 추론 결과를 반환합니다."
     )
     @PostMapping(value = "/api/ai/recognitions", consumes = "multipart/form-data")
-    APIResponse<AiResponseDto> recognition(
+    APIResponse<List<ResAiMedicineDto>> recognition(
             @RequestParam("image") MultipartFile imageFile
     );
 }

--- a/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
+++ b/src/main/java/hexfive/ismedi/global/swagger/FastApiDocs.java
@@ -18,7 +18,7 @@ public interface FastApiDocs {
             description = "이미지 파일을 업로드하면 AI 모델을 통해 약 이름 및 추론 결과를 반환합니다."
     )
     @PostMapping(value = "/api/ai/recognitions", consumes = "multipart/form-data")
-    APIResponse<List<AiResponseDto>> recognition(
+    APIResponse<AiResponseDto> recognition(
             @RequestParam("image") MultipartFile imageFile
     );
 }


### PR DESCRIPTION
## 📝 기능 설명
AI 서버로부터 약 이미지 추론 결과 받아오는 포맷 수정하였습니다.

## 🛠 작업 사항
AI 서버 응답 형태 구조 개선, 그에 맞게 백엔드에서 받는 응답 DTO 수정하였습니다.

- Fast API 로 이미지 잘 들어갔고 모델 인식 성공 -> "success": true, "data": { ... }
- Fast API 로 이미지는 잘 들어갔는데 모델이 약 인식 실패 -> "success": true, "data": null

"box" 로 받는 값들은 모델이 이미지에서 인식한 약의 픽셀 위치라고 들었습니다. 
이것도 프론트에서 활용 가능한 데이터긴 해서 일단 응답에 같이 넣어두었습니다.
"primary_prediction" 는 정확도가 가장 높은 약의 id와 confidence,
"top_predictions" 는 "primary_prediction" 를 포함한 정확도 상위 5개 약의 id와 confidence입니다.

아래는 AI 서버에서 반환하는 응답입니다.
```
{
    "success": true,
    "detected": true,
    "data": {
        "box": [322, 167, 469, 312 ],
        "primary_prediction": {
            "class_id": 31,
            "confidence": 0.49
        },
        "top_predictions": [
            {
                "class_id": 31,
                "confidence": 0.49
            },
            ...
        ]
    }
}
```
그리고 이에 따라 백에서 프론트로 반환하는 응답입니다.
```
{
    "success": true,
    "message": "성공적으로 응답되었습니다",
    "data": [
        {
            "medicine": {
                "id": 1890,
                "name": "지엘타이밍정(카페인무수물)",
                "image": "https://nedrug.mfds.go.kr/pbp/cmn/itemImageDownload/1NAT_bwbZd9",
                "type": "일반의약품",
                "className": "각성제,흥분제",
                "efficacy": "이 약은 졸음에 사용합니다.",
                ...
            },
            "confidence": 0.03
        },
        ...
        ]
    }
}
```
어제 8000번 포트 열어주셨는데도 커넥션 에러가 나서 승우님께 물어보니, 현재 저희 EC2 인스턴스에 Fast API 서버 띄워주는 uvicorn 실행 커맨드가 아직 안 올라가져 있다고 합니다. 
그래서 EC2에 띄워진 AI 서버가 아니라 로컬에서 테스트 하긴 했는데, AI 모델을 로컬에 다운로드 받아서 직접 실행하고 테스트해본거라, 아마 다른 에러 사항이 생기진 않을 것 같습니다..!!

## ✅ 작업 체크리스트
- [x] AI 서버에서 반환하는 응답 포맷과 백엔드 서버에서 받는 응답 포맷 일치
- [x] 인식 실패할 경우 처리

## 📎 참고 자료
백엔드 서버로 요청
![image](https://github.com/user-attachments/assets/5bf78514-7a33-420a-bf9f-afd3c277bac5)

AI 서버로 직접 요청
![image](https://github.com/user-attachments/assets/feb2494a-da28-43a4-baf9-c7ed68ac3733)

약 이미지가 아닌 이미지 담아서 요청
![image](https://github.com/user-attachments/assets/3a9701ca-983f-42c4-9c00-e3f01aca126e)

