### PR TITLE
AI 서버로부터 받는 응답 형식에 따라 변경

### DIFF
--- a/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiClient.java
@@ -5,10 +5,13 @@ import hexfive.ismedi.fastApi.dto.AiResponseWrapperDto;
 import hexfive.ismedi.fastApi.dto.ResAiMedicineDto;
 import hexfive.ismedi.global.exception.CustomException;
 import hexfive.ismedi.global.response.APIResponse;
+import hexfive.ismedi.medicine.Medicine;
+import hexfive.ismedi.medicine.MedicineRepository;
 import hexfive.ismedi.medicine.MedicineService;
 import hexfive.ismedi.medicine.dto.ResMedicineDetailDto;
 import hexfive.ismedi.medicine.dto.ResMedicineDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,11 +28,12 @@ import static hexfive.ismedi.global.exception.ErrorCode.AI_SERVER_ERROR;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class FastApiClient {
 
     @Value("${ai.server.url}")
     private String aiServerUrl;
-    private final MedicineService medicineService;
+    private final MedicineRepository medicineRepository;
 
     public List<ResAiMedicineDto> sendImage(Path imagePath){
         FileSystemResource imageResource = new FileSystemResource(imagePath);
@@ -61,10 +65,11 @@ public class FastApiClient {
 
            return responseBody.getData().getTopPredictions().stream()
                     .map(prediction -> {
-                        Long id = prediction.getClassId();
+                        String itemSeq = prediction.getClassId().toString();
                         double confidence = prediction.getConfidence();
-                        ResMedicineDetailDto resMedicineDetailDto = medicineService.getMedicine(id);
-                        return ResAiMedicineDto.of(resMedicineDetailDto, confidence);
+                        Medicine medicine = medicineRepository.findByItemSeq(itemSeq)
+                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 약 id 입니다." + itemSeq));
+                        return ResAiMedicineDto.of(ResMedicineDetailDto.fromEntity(medicine), confidence);
                     })
                     .toList();
         }catch (Exception e){

--- a/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
+++ b/src/main/java/hexfive/ismedi/fastApi/FastApiService.java
@@ -25,14 +25,9 @@ public class FastApiService {
     public List<ResAiMedicineDto> recognize(MultipartFile imageFile){
         String path = saveImage(imageFile);
         Path imagePath = Paths.get(path);
-        try{
             List<ResAiMedicineDto> response = sendToAiServer(imagePath);
             deleteImage(imagePath);
             return response;
-        } catch (Exception e){
-            try{deleteImage(imagePath);} catch(Exception ignore){}
-            throw new CustomException(INTERNAL_ERROR);
-        }
     }
 
     public String saveImage(MultipartFile imageFile) {
@@ -63,7 +58,11 @@ public class FastApiService {
         return fastApiClient.sendImage(imagePath);
     }
 
-    private void deleteImage(Path imagePath) throws IOException {
-        Files.deleteIfExists(imagePath);
+    private void deleteImage(Path imagePath) {
+        try {
+            Files.deleteIfExists(imagePath);
+        } catch (IOException e) {
+            throw new IllegalStateException("이미지 제거 실패");
+        }
     }
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
@@ -12,5 +12,6 @@ public class AiClassProbDto {
     @JsonProperty("class_id")
     private String classId;
 
+    @JsonProperty("similarity")
     private double confidence;
 }

--- a/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
+++ b/src/main/java/hexfive/ismedi/fastApi/dto/AiClassProbDto.java
@@ -3,12 +3,14 @@ package hexfive.ismedi.fastApi.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
+@ToString
 public class AiClassProbDto {
     @JsonProperty("class_id")
-    private Long classId;
+    private String classId;
 
     private double confidence;
 }

--- a/src/main/java/hexfive/ismedi/medicine/MedicineRepository.java
+++ b/src/main/java/hexfive/ismedi/medicine/MedicineRepository.java
@@ -1,15 +1,19 @@
 package hexfive.ismedi.medicine;
 
+import hexfive.ismedi.medicine.dto.ResMedicineDetailDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MedicineRepository extends JpaRepository<Medicine, Long> {
     List<Medicine> findAllByItemNameContaining(String name);
     List<Medicine> findAllByEtcOtcCode(String type);
     List<Medicine> findAllByItemNameContainingAndEtcOtcCode(String name, String type);
+
+    Optional<Medicine> findByItemSeq(String itemSeq);
 }


### PR DESCRIPTION
## 📝 기능 설명
itemSeq로 약을 전달받아 약 정보를 조회하여 응답하도록 하였습니다.

## 🛠 작업 사항
AI서버와 데이터베이스 서버에서 모두 식별 가능한 약의 종류인 itemSeq를 기준으로 응답을 주고받도록 하였습니다
프론트에 응답하는 형식은 동일하고 AI 서버에서 응답받는 형식만 변경되어 맞추었습니다.

![image](https://github.com/user-attachments/assets/7922e690-4dc0-4894-a989-6df2eb24ed12)

## ✅ 작업 체크리스트
- [x] AI 서버 응답 형식 맞추어 연동
- [x] 예외처리 분리

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
